### PR TITLE
Add AnalogEmulatorDataGroup for analog emulator output

### DIFF
--- a/src/oqd_dataschema/__init__.py
+++ b/src/oqd_dataschema/__init__.py
@@ -18,6 +18,7 @@ from .dataset import CastDataset, Dataset
 from .datastore import Datastore
 from .folder import CastFolder, Folder
 from .group import GroupBase, GroupRegistry
+from .groups import AnalogEmulatorDataGroup
 from .table import CastTable, Table
 from .utils import dict_to_structured, unstructured_to_structured
 
@@ -40,4 +41,5 @@ __all__ = [
     "confolder",
     "dict_to_structured",
     "unstructured_to_structured",
+    "AnalogEmulatorDataGroup",
 ]

--- a/src/oqd_dataschema/groups/__init__.py
+++ b/src/oqd_dataschema/groups/__init__.py
@@ -1,0 +1,17 @@
+# Copyright 2024-2025 Open Quantum Design
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .analog_emulator import AnalogEmulatorDataGroup
+
+__all__ = ["AnalogEmulatorDataGroup"]

--- a/src/oqd_dataschema/groups/analog_emulator.py
+++ b/src/oqd_dataschema/groups/analog_emulator.py
@@ -1,0 +1,47 @@
+# Copyright 2024-2025 Open Quantum Design
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Optional
+
+from oqd_dataschema.dataset import Dataset
+from oqd_dataschema.group import GroupBase
+
+########################################################################################
+
+__all__ = ["AnalogEmulatorDataGroup"]
+
+########################################################################################
+
+
+class AnalogEmulatorDataGroup(GroupBase):
+    """
+    Processed output from an OQD analog classical emulator (e.g. QuTiP).
+
+    Datasets:
+        times: 1D float array of length ``n_tsteps``.
+        metrics: 2D float array of shape ``(n_tsteps, n_metrics)`` with metric
+            names stored in ``metrics.attrs["metric_labels"]`` (JSON list).
+        state: 2D complex array of shape ``(n_tsteps, state_dim)`` for the state
+            trajectory over the simulation.
+        measurements: 2D int array of shape ``(n_shots, n_qubits)`` when shots
+            were sampled after a measurement instruction.
+
+    Group ``attrs`` hold run metadata (``dt``, ``n_shots``, ``fock_cutoff``,
+    backend identifier, version, etc.).
+    """
+
+    times: Dataset
+    metrics: Optional[Dataset] = None
+    state: Optional[Dataset] = None
+    measurements: Optional[Dataset] = None

--- a/tests/test_analog_emulator_group.py
+++ b/tests/test_analog_emulator_group.py
@@ -1,0 +1,43 @@
+# Copyright 2024-2025 Open Quantum Design
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import uuid
+
+import numpy as np
+
+from oqd_dataschema import AnalogEmulatorDataGroup, Datastore, Dataset, GroupRegistry
+
+
+def test_analog_emulator_group_registered():
+    assert "AnalogEmulatorDataGroup" in GroupRegistry.groups
+
+
+def test_analog_emulator_hdf5_roundtrip(tmp_path):
+    filepath = tmp_path / f"analog_{uuid.uuid4()}.h5"
+    group = AnalogEmulatorDataGroup(
+        attrs={"backend": "qutip", "dt": 0.001, "fock_cutoff": 4},
+        times=Dataset(data=np.linspace(0, 1, 5, dtype=np.float64)),
+        metrics=Dataset(
+            data=np.zeros((5, 1), dtype=np.float64),
+            attrs={"metric_labels": json.dumps(["Z"])},
+        ),
+        state=Dataset(data=np.zeros((5, 2), dtype=np.complex128)),
+    )
+    datastore = Datastore(groups={"emulation": group})
+    datastore.model_dump_hdf5(filepath)
+    reloaded = Datastore.model_validate_hdf5(filepath)
+    sim = reloaded.groups["emulation"]
+    assert sim.attrs["backend"] == "qutip"
+    assert json.loads(sim.metrics.attrs["metric_labels"]) == ["Z"]


### PR DESCRIPTION
## Summary

Adds `AnalogEmulatorDataGroup` - the shared HDF5 schema for classical analog emulator runs (unitaryHACK / oqd-analog-emulator [#9](https://github.com/OpenQuantumDesign/oqd-analog-emulator/issues/9)).

**Datasets:** `times`, `metrics` (2D + `metric_labels` in attrs as JSON), `state` (2D trajectory), optional `measurements`.

**Group attrs:** run metadata (`backend`, `dt`, `fock_cutoff`, `n_shots`, etc.).

## Why separate PR

Emulator backends should not define their own on-disk format. This group is registered in `GroupRegistry` and exported from `oqd_dataschema`.

## Test plan

- [x] `pytest tests/test_analog_emulator_group.py` — registration + HDF5 round-trip
- [x] Full suite: **147 passed**, 57 xfailed (unchanged from `main`)

## Merge order

**Merge this before** [oqd-analog-emulator #10](https://github.com/OpenQuantumDesign/oqd-analog-emulator/pull/10).